### PR TITLE
fix: display closing reason in issue detail Recent Events section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,10 +239,11 @@ Write operations use [HTMX](https://htmx.org/) for dynamic updates:
 
 **Issue Detail Page** ([detail.html](assets/beady/templates/detail.html)):
 - Status/Priority dropdowns with inline update
-- Close button with modal dialog for reason
+- Close button with modal dialog for reason (reason stored in event audit trail)
 - Comment form that reloads page on submit
 - Label add/remove with inline controls
 - Notes section with edit form in collapsible details
+- Recent Events section showing audit trail with timestamps, actors, event types, and details (e.g., closing reasons for StatusChanged events)
 - All actions include username from localStorage
 
 **Issue Creation** ([issue_form.html](assets/beady/templates/issue_form.html)):

--- a/assets/beady/templates/detail.html
+++ b/assets/beady/templates/detail.html
@@ -186,7 +186,11 @@
             <h3>Recent Events</h3>
             <ul>
                 {{range .Events}}
-                <li>{{.CreatedAt}}: {{.EventType}}</li>
+                <li>
+                    <strong>{{.CreatedAt}}</strong>{{if .Actor}} by {{.Actor}}{{end}}: {{.EventType}}
+                    {{if .OldValue}}<br>{{.OldValue}} → {{.NewValue}}{{end}}
+                    {{if .Comment}}<br><em>{{.Comment}}</em>{{end}}
+                </li>
                 {{end}}
             </ul>
             {{if not .Events}}<p>No recent events.</p>{{end}}


### PR DESCRIPTION
## Summary
- Display closing reason in Recent Events section of issue detail page
- Show event actor (who made the change)
- Display status transitions and other event details

## Test Plan
- [x] Verified with manual testing: closed an issue with reason "Completed as part of sprint"
- [x] Confirmed reason now appears in Recent Events section
- [x] Confirmed actor name and event type display correctly
- [x] Build succeeds (go build -o beady ./cmd/beady)

## Implementation Details
Updated [detail.html](assets/beady/templates/detail.html) Recent Events section to render:
- Event timestamp and actor (`{{.CreatedAt}}` and `{{.Actor}}`)
- Event type (`{{.EventType}}`)
- Status transitions for StatusChanged events (`{{.OldValue}} → {{.NewValue}}`)
- Event comment/reason for closing events (`{{.Comment}}`)

Updated [CLAUDE.md](CLAUDE.md) documentation to describe Recent Events section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Recent Events section to display audit trail details including event timestamps, actors, event types, and closing reasons.
  * Enhanced event display with additional context such as value changes and comments.

* **UI Changes**
  * Updated Close button label to clarify that closing reasons are stored in the audit trail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->